### PR TITLE
XAML textures sampling support

### DIFF
--- a/render-only-sample/roscommon/Vc4Hw.h
+++ b/render-only-sample/roscommon/Vc4Hw.h
@@ -990,22 +990,52 @@ typedef enum _VC4TextureMinFilter
 const UINT VC4_BINNING_TILE_PIXELS  = 64;
 
 //
-// Constants related to tiled textures
+// Structure and constants related to tiled textures
 //
 
-const UINT VC4_1KB_SUB_TILE_WIDTH       = 16;
-const UINT VC4_1KB_SUB_TILE_HEIGHT      = 16;
-const UINT VC4_1KB_SUB_TILE_WIDTH_BYTES = 64;
-const UINT VC4_1KB_SUB_TILE_SIZE_BYTES  = 1024;
+typedef struct _VC4TileInfo
+{
+    UINT VC4_4kBTileWidthPixels;
+    UINT VC4_4kBTileHeightPixels;
+    UINT VC4_4kBTileWidthBytes;
 
-const UINT VC4_4KB_TILE_WIDTH           = 32;
-const UINT VC4_4KB_TILE_HEIGHT          = 32;
-const UINT VC4_4KB_TILE_WIDTH_BYTES     = 128;
-const UINT VC4_4KB_TILE_SIZE_BYTES      = 4096;
+    UINT VC4_1kBSubTileWidthPixels;
+    UINT VC4_1kBSubTileHeightPixels;
+    UINT VC4_1kBSubTileWidthBytes;
 
-const UINT VC4_MICRO_TILE_WIDTH_BYTES   = 16;
-const UINT VC4_MICRO_TILE_HEIGHT        = 4;
-const UINT VC4_MICRO_TILE_SIZE_BYTES    = 64;
+    UINT VC4_MicroTileWidthBytes;
+    UINT vC4_MicroTileHeight;
+
+} VC4TileInfo;
+
+// General tiles, sub-tiles and micro-tiles information
+const UINT VC4_MICRO_TILE_SIZE_BYTES            = 64;
+const UINT VC4_1KB_SUB_TILE_SIZE_BYTES          = 1024;
+const UINT VC4_4KB_TILE_SIZE_BYTES              = 4096;
+
+// Precalculated values for 32 bpp tile
+const UINT VC4_1KB_SUB_TILE_WIDTH_32BPP         = 16;
+const UINT VC4_1KB_SUB_TILE_HEIGHT_32BPP        = 16;
+
+const UINT VC4_MICRO_TILE_WIDTH_32BPP           = 4;
+const UINT VC4_MICRO_TILE_HEIGHT_32BPP          = 4;
+const UINT VC4_MICRO_TILE_WIDTH_BYTES_32BPP     = 16;
+
+// Precalculated values for 16 bpp tile
+const UINT VC4_1KB_SUB_TILE_WIDTH_16BPP         = 16;
+const UINT VC4_1KB_SUB_TILE_HEIGHT_16BPP        = 32;
+
+const UINT VC4_MICRO_TILE_WIDTH_16BPP           = 4;
+const UINT VC4_MICRO_TILE_HEIGHT_16BPP          = 8;
+const UINT VC4_MICRO_TILE_WIDTH_BYTES_16BPP     = 8;
+
+// Precalculated values for 8 bpp tile
+const UINT VC4_1KB_SUB_TILE_WIDTH_8BPP          = 32;
+const UINT VC4_1KB_SUB_TILE_HEIGHT_8BPP         = 32;
+
+const UINT VC4_MICRO_TILE_WIDTH_8BPP            = 8;
+const UINT VC4_MICRO_TILE_HEIGHT_8BPP           = 8;
+const UINT VC4_MICRO_TILE_WIDTH_BYTES_8BPP      = 8;
 
 //
 // VC4 bus address alias

--- a/render-only-sample/roscompiler/Vc4Shader.cpp
+++ b/render-only-sample/roscompiler/Vc4Shader.cpp
@@ -652,7 +652,7 @@ void Vc4Shader::Emit_Sample(CInstruction &Inst)
     VC4_ASSERT((texFormat == DXGI_FORMAT_B8G8R8A8_UNORM) || (texFormat == DXGI_FORMAT_R8G8B8A8_UNORM));
         
     // TODO: more generic color channel swizzle support.
-    boolean bSwapColorChannel = (texFormat != DXGI_FORMAT_R8G8B8A8_UNORM);
+    boolean bSwapColorChannel = false;// (texFormat != DXGI_FORMAT_R8G8B8A8_UNORM);
     
     // Texture coordinate
     VC4_ASSERT(Inst.m_Operands[1].m_NumComponents == D3D10_SB_OPERAND_4_COMPONENT);

--- a/render-only-sample/roscompiler/Vc4Shader.cpp
+++ b/render-only-sample/roscompiler/Vc4Shader.cpp
@@ -652,8 +652,11 @@ void Vc4Shader::Emit_Sample(CInstruction &Inst)
     VC4_ASSERT((texFormat == DXGI_FORMAT_B8G8R8A8_UNORM) || (texFormat == DXGI_FORMAT_R8G8B8A8_UNORM));
         
     // TODO: more generic color channel swizzle support.
-    boolean bSwapColorChannel = false;// (texFormat != DXGI_FORMAT_R8G8B8A8_UNORM);
-    
+    boolean bSwapColorChannel = (texFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+        && (texFormat != DXGI_FORMAT_R8G8_UNORM)
+        && (texFormat != DXGI_FORMAT_R8_UNORM)
+        && (texFormat != DXGI_FORMAT_A8_UNORM);
+
     // Texture coordinate
     VC4_ASSERT(Inst.m_Operands[1].m_NumComponents == D3D10_SB_OPERAND_4_COMPONENT);
     VC4_ASSERT(Inst.m_Operands[1].m_IndexDimension == D3D10_SB_OPERAND_INDEX_1D);

--- a/render-only-sample/roscompiler/Vc4Shader.cpp
+++ b/render-only-sample/roscompiler/Vc4Shader.cpp
@@ -649,7 +649,11 @@ void Vc4Shader::Emit_Sample(CInstruction &Inst)
     uint32_t texDimension = this->ResourceDimension[resourceIndex];
 
     DXGI_FORMAT texFormat = UmdCompiler->GetShaderResourceFormat((uint8_t)resourceIndex);
-    VC4_ASSERT((texFormat == DXGI_FORMAT_B8G8R8A8_UNORM) || (texFormat == DXGI_FORMAT_R8G8B8A8_UNORM));
+    VC4_ASSERT((texFormat == DXGI_FORMAT_B8G8R8A8_UNORM)
+        || (texFormat == DXGI_FORMAT_R8G8B8A8_UNORM)
+        || (texFormat == DXGI_FORMAT_R8G8_UNORM)
+        || (texFormat == DXGI_FORMAT_R8_UNORM)
+        || (texFormat == DXGI_FORMAT_A8_UNORM));
         
     // TODO: more generic color channel swizzle support.
     boolean bSwapColorChannel = (texFormat != DXGI_FORMAT_R8G8B8A8_UNORM)

--- a/render-only-sample/rosumd/RosUmdDevice.cpp
+++ b/render-only-sample/rosumd/RosUmdDevice.cpp
@@ -296,32 +296,6 @@ void RosUmdDevice::CreateResource(const D3D11DDIARG_CREATERESOURCE* pCreateResou
             BYTE * pDst = (BYTE *)lock.pData;
             UINT  rowStride = pCreateResource->pInitialDataUP[0].SysMemPitch;
             pResource->ConvertInitialTextureFormatToInternal(pSrc, pDst, rowStride);
-
-#if 0
-            if (pResource->m_hwLayout == RosHwLayout::Linear)
-            {
-                BYTE *  pSrc = (BYTE *)pCreateResource->pInitialDataUP[0].pSysMem;
-                BYTE *  pDst = (BYTE *)lock.pData;
-
-                for (UINT i = 0; i < pResource->m_mip0Info.TexelHeight; i++)
-                {
-                    memcpy(pDst, pSrc, pCreateResource->pInitialDataUP[0].SysMemPitch);
-
-                    pSrc += pCreateResource->pInitialDataUP[0].SysMemPitch;
-                    pDst += pResource->m_hwPitchBytes;
-                }
-            }
-            else
-            {
-                // Texture tiled mode support
-                BYTE * pSrc = (BYTE *)pCreateResource->pInitialDataUP[0].pSysMem;
-                BYTE * pDst = (BYTE *)lock.pData;
-                UINT  rowStride = pCreateResource->pInitialDataUP[0].SysMemPitch;
-
-                // Swizzle texture to HW format
-                pResource->ConvertBitmapTo4kTileBlocks(pSrc, pDst, rowStride);
-            }
-#endif
         }
         else
         {

--- a/render-only-sample/rosumd/RosUmdDevice.h
+++ b/render-only-sample/rosumd/RosUmdDevice.h
@@ -292,6 +292,10 @@ private:
         UINT                       &curCommandOffset,
         D3DDDI_PATCHLOCATIONLIST * &pCurPatchLocation);
 
+    VC4TextureType MapDXGITextureFormatToVC4Type(
+        RosHwLayout layout,
+        DXGI_FORMAT format);
+
 #endif
 
 public:

--- a/render-only-sample/rosumd/RosUmdResource.cpp
+++ b/render-only-sample/rosumd/RosUmdResource.cpp
@@ -333,6 +333,13 @@ void MapDxgiFormatToInternalFormats(DXGI_FORMAT format, UINT &bpp, RosHwFormat &
     }
     break;
 
+    case DXGI_FORMAT_A8_UNORM:
+    {
+        bpp = 32;
+        rosFormat = RosHwFormat::X8888;
+    }
+    break;
+
     default:
         bpp = 8;
         rosFormat = RosHwFormat::X8;

--- a/render-only-sample/rosumd/RosUmdResource.cpp
+++ b/render-only-sample/rosumd/RosUmdResource.cpp
@@ -18,7 +18,7 @@ RosUmdResource::RosUmdResource() :
     m_signature(_SIGNATURE::CONSTRUCTED),
     m_hKMAllocation(NULL)
 {
-    // do nothing
+    memset(&m_TileInfo, 0, sizeof(m_TileInfo));
 }
 
 RosUmdResource::~RosUmdResource()
@@ -263,6 +263,109 @@ RosUmdResource::Unmap(
 }
 
 void
+RosUmdResource::FillTileInfo(UINT bpp)
+{
+    // Provide detailed information about tile.
+    // Partial information about 4kB tiles, 1kB sub-tiles and micro-tiles for
+    // given bpp is precalculated.
+    // Values are used i.e. during converting bitmap to tiled texture
+
+    if (bpp == 8)
+    {
+        m_TileInfo.VC4_1kBSubTileWidthPixels        = VC4_1KB_SUB_TILE_WIDTH_8BPP;
+        m_TileInfo.VC4_1kBSubTileHeightPixels       = VC4_1KB_SUB_TILE_HEIGHT_8BPP;
+        m_TileInfo.VC4_MicroTileWidthBytes          = VC4_MICRO_TILE_WIDTH_BYTES_8BPP;
+        m_TileInfo.vC4_MicroTileHeight              = VC4_MICRO_TILE_HEIGHT_8BPP;
+    }
+    else
+    if (bpp == 16)
+    {
+        m_TileInfo.VC4_1kBSubTileWidthPixels        = VC4_1KB_SUB_TILE_WIDTH_16BPP;
+        m_TileInfo.VC4_1kBSubTileHeightPixels       = VC4_1KB_SUB_TILE_HEIGHT_16BPP;
+        m_TileInfo.VC4_MicroTileWidthBytes          = VC4_MICRO_TILE_WIDTH_BYTES_16BPP;
+        m_TileInfo.vC4_MicroTileHeight              = VC4_MICRO_TILE_HEIGHT_16BPP;
+    }
+    else
+    if (bpp == 32)
+    {
+        m_TileInfo.VC4_1kBSubTileWidthPixels        = VC4_1KB_SUB_TILE_WIDTH_32BPP;
+        m_TileInfo.VC4_1kBSubTileHeightPixels       = VC4_1KB_SUB_TILE_HEIGHT_32BPP;
+        m_TileInfo.VC4_MicroTileWidthBytes          = VC4_MICRO_TILE_WIDTH_BYTES_32BPP;
+        m_TileInfo.vC4_MicroTileHeight              = VC4_MICRO_TILE_HEIGHT_32BPP;
+    }
+    
+    // Calculate sub-tile width in bytes
+    m_TileInfo.VC4_1kBSubTileWidthBytes = m_TileInfo.VC4_1kBSubTileWidthPixels * (bpp / 8);
+    
+    // 4kB tile consists of four 1kB sub-tiles
+    m_TileInfo.VC4_4kBTileWidthPixels = m_TileInfo.VC4_1kBSubTileWidthPixels * 2;
+    m_TileInfo.VC4_4kBTileHeightPixels = m_TileInfo.VC4_1kBSubTileHeightPixels * 2;
+    m_TileInfo.VC4_4kBTileWidthBytes = m_TileInfo.VC4_1kBSubTileWidthBytes * 2;
+}
+
+void MapDxgiFormatToInternalFormats(DXGI_FORMAT format, UINT &bpp, RosHwFormat &rosFormat)
+{
+
+    // Number of HW formats is limited, so some of DXGI formats must be emulated.
+    // For example, format DXGI_FORMAT_R8_UNORM is emulated with  DXGI_FORMAT_R8G8B8A8_UNORM 
+    // where G8, B8 are set to 0
+    // 
+    switch (format)
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    {
+        bpp = 32;
+        rosFormat = RosHwFormat::X8888;
+    }
+    break;
+
+    case DXGI_FORMAT_R8G8_UNORM:
+    {
+        bpp = 32;
+        rosFormat = RosHwFormat::X8888;
+    }
+    break;
+
+    case DXGI_FORMAT_R8_UNORM:
+    {
+        bpp = 32;
+        rosFormat = RosHwFormat::X8888;
+    }
+    break;
+
+    default:
+        bpp = 8;
+        rosFormat = RosHwFormat::X8;
+    }
+}
+
+void
+RosUmdResource::CalculateTilesInfo()
+{
+    UINT bpp = 0;
+
+    // Provide information about hardware formats
+    MapDxgiFormatToInternalFormats(m_format, bpp, m_hwFormat);
+
+    // Prepare information about tiles
+    FillTileInfo(bpp);
+
+    m_hwWidthTilePixels = m_TileInfo.VC4_4kBTileWidthPixels;
+    m_hwHeightTilePixels = m_TileInfo.VC4_4kBTileHeightPixels;
+
+    m_hwWidthTiles = (m_hwWidthPixels + m_hwWidthTilePixels - 1) / m_hwWidthTilePixels;
+    m_hwHeightTiles = (m_hwHeightPixels + m_hwHeightTilePixels - 1) / m_hwHeightTilePixels;
+    m_hwWidthPixels = m_hwWidthTiles*m_hwWidthTilePixels;
+    m_hwHeightPixels = m_hwHeightTiles*m_hwHeightTilePixels;
+
+    UINT sizeTileBytes = m_hwWidthTilePixels * m_hwHeightTilePixels * (bpp/8);
+
+    m_hwSizeBytes = m_hwWidthTiles * m_hwHeightTiles * sizeTileBytes;
+    m_hwPitchBytes = 0;
+
+}
+
+void
 RosUmdResource::SetLockFlags(
     D3D10_DDI_MAP mapType,
     UINT mapFlags,
@@ -379,23 +482,7 @@ RosUmdResource::CalculateMemoryLayout(
             }
             else
             {
-                assert(m_hwLayout == RosHwLayout::Tiled);
-                assert(m_mipLevels == 1);
-
-                assert((m_hwFormat == RosHwFormat::X8888) || (m_hwFormat == RosHwFormat::D24S8));
-                
-                // Values are hardocded - we are using RosHwFormat::X8888 format
-                m_hwWidthTilePixels = VC4_4KB_TILE_WIDTH;
-                m_hwHeightTilePixels = VC4_4KB_TILE_HEIGHT;
-                m_hwWidthTiles = (m_hwWidthPixels + m_hwWidthTilePixels - 1) / m_hwWidthTilePixels;
-                m_hwHeightTiles = (m_hwHeightPixels + m_hwHeightTilePixels - 1) / m_hwHeightTilePixels;
-                m_hwWidthPixels = m_hwWidthTiles*m_hwWidthTilePixels;
-                m_hwHeightPixels = m_hwHeightTiles*m_hwHeightTilePixels;
-
-                UINT sizeTileBytes = m_hwWidthTilePixels * m_hwHeightTilePixels * 4;
-
-                m_hwSizeBytes = m_hwWidthTiles * m_hwHeightTiles * sizeTileBytes;
-                m_hwPitchBytes = 0;
+                CalculateTilesInfo();
             }
         }
         break;
@@ -449,24 +536,151 @@ bool RosUmdResource::CanRotateFrom(const RosUmdResource* Other) const
            (m_hwHeightTiles == Other->m_hwHeightTiles);
 }
 
+
+// Converts R, RG or A buffer to 32 bpp (RGBA) buffer
+void  RosUmdResource::ConvertBufferto32Bpp(BYTE *pSrc, BYTE *pDst, UINT srcBpp, UINT swizzleMask, UINT pSrcStride, UINT pDstStride)
+{
+    for (UINT i = 0; i < m_mip0Info.TexelHeight; i++)
+    {
+        DWORD *dstSwizzled = (DWORD*)pDst;
+
+        UINT dstIndex = 0;
+        for (UINT k = 0; k < m_mip0Info.TexelWidth*srcBpp; k += srcBpp)
+        {
+            DWORD swizzledRGBA = 0;
+
+            // Gather individual color elements into one DWORD
+            for (UINT colorElement = 0; colorElement < srcBpp; colorElement++)
+            {
+                DWORD currentColorElement = (DWORD)pSrc[k + colorElement];
+
+                // Move element to the right position
+                currentColorElement = currentColorElement << (colorElement << 3);
+                swizzledRGBA = swizzledRGBA | currentColorElement;
+            }
+
+            swizzledRGBA = swizzledRGBA << swizzleMask;
+            dstSwizzled[dstIndex] = swizzledRGBA;
+            dstIndex += 1;
+        }
+
+        pSrc += pSrcStride;
+        pDst += pDstStride;
+    }
+}
+
+// Converts texture to internal (HW friendly) representation
+void RosUmdResource::ConvertInitialTextureFormatToInternal(BYTE *pSrc, BYTE *pDst, UINT rowStride)
+{
+    // HW supports only limited set of formats, so most of DXGI formats must
+    // be converted at the beginning.    
+    UINT swizzleMask = 0;
+    UINT srcBpp = 0;
+ 
+    switch (m_format)
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    {
+        // Do nothing
+    }
+    break;
+
+    case DXGI_FORMAT_R8_UNORM:
+    {
+        swizzleMask = 0;
+        srcBpp = 1;
+    }
+    break;
+
+    case DXGI_FORMAT_R8G8_UNORM:
+    {
+        swizzleMask = 0;
+        srcBpp = 2;
+    }
+    break;
+
+    case DXGI_FORMAT_A8_UNORM:
+    {
+        swizzleMask = 24;
+        srcBpp = 1;
+    }
+    break;
+
+    default:
+    {
+    
+    }
+    break;
+    }
+   
+    // For DXGI_FORMAT_R8G8B8A8_UNORM we can do a simple copy or swizzle 
+    // texture directly to memory.
+    if (m_format == DXGI_FORMAT_R8G8B8A8_UNORM)
+    {
+        if (m_hwLayout == RosHwLayout::Linear)
+        {
+            for (UINT i = 0; i < m_mip0Info.TexelHeight; i++)
+            {
+                memcpy(pDst, pSrc, rowStride);
+
+                pSrc += rowStride;
+                pDst += m_hwPitchBytes;
+            }
+        }
+        else
+        {
+            // Swizzle texture to HW format
+            ConvertBitmapTo4kTileBlocks(pSrc, pDst, rowStride);
+        }
+    }
+    else
+    {
+        // We have to convert other formats to internal format         
+        if (m_hwLayout == RosHwLayout::Linear)
+        {
+            // Do a conversion directly to the locked allocation
+            ConvertBufferto32Bpp(pSrc, pDst, srcBpp, swizzleMask, rowStride, m_hwPitchBytes);            
+        }
+        else
+        {
+            // For tiled layout, additional buffer is allocated. It is a 
+            // conversion (temporary) buffer.
+            UINT pitch = m_mip0Info.TexelHeight * m_mip0Info.TexelWidth * 4;
+            PBYTE temporary = new BYTE[pitch];
+            if (NULL == temporary)
+            {
+                throw RosUmdException(E_OUTOFMEMORY);
+            }
+
+            UINT dstStride = m_mip0Info.TexelWidth * 4;
+
+            ConvertBufferto32Bpp(pSrc, temporary, srcBpp, swizzleMask, rowStride, dstStride);
+
+            ConvertBitmapTo4kTileBlocks(temporary, pDst, dstStride);
+
+            delete[] temporary;
+        }
+    }
+}
+
 // Form 1k sub-tile block
 BYTE *RosUmdResource::Form1kSubTileBlock(BYTE *pInputBuffer, BYTE *pOutBuffer, UINT rowStride)
 {    
     // 1k sub-tile block is formed from micro-tiles blocks
-    for (UINT h = 0; h < VC4_1KB_SUB_TILE_HEIGHT; h += 4)
+    for (UINT h = 0; h < m_TileInfo.VC4_1kBSubTileHeightPixels; h += m_TileInfo.vC4_MicroTileHeight)
     {
         BYTE *currentBufferPos = pInputBuffer + h*rowStride;
 
         // Process row of 4 micro-tiles blocks
-        for (UINT w = 0; w < VC4_1KB_SUB_TILE_WIDTH_BYTES; w+= VC4_MICRO_TILE_WIDTH_BYTES)
+        for (UINT w = 0; w < m_TileInfo.VC4_1kBSubTileWidthBytes; w+= m_TileInfo.VC4_MicroTileWidthBytes)
         {
             BYTE *microTileOffset = currentBufferPos + w;
 
-            // Process micro-tile block (4x16 bytes)
-            for (int t = 0; t < VC4_MICRO_TILE_HEIGHT; t++)
+            // Process micro-tile block
+            for (UINT t = 0; t < m_TileInfo.vC4_MicroTileHeight; t++)
             {
-                memcpy(pOutBuffer, microTileOffset, VC4_MICRO_TILE_WIDTH_BYTES);
-                pOutBuffer += VC4_MICRO_TILE_WIDTH_BYTES;
+                memcpy(pOutBuffer, microTileOffset, m_TileInfo.VC4_MicroTileWidthBytes);
+                pOutBuffer += m_TileInfo.VC4_MicroTileWidthBytes;
                 microTileOffset += rowStride;
             }
         }
@@ -478,6 +692,9 @@ BYTE *RosUmdResource::Form1kSubTileBlock(BYTE *pInputBuffer, BYTE *pOutBuffer, U
 BYTE *RosUmdResource::Form4kTileBlock(BYTE *pInputBuffer, BYTE *pOutBuffer, UINT rowStride, BOOLEAN OddRow)
 {
     BYTE *currentTileOffset = NULL;
+   
+    UINT subTileHeightPixels        = m_TileInfo.VC4_1kBSubTileHeightPixels;
+    UINT subTileWidthBytes          = m_TileInfo.VC4_1kBSubTileWidthBytes;
 
     if (OddRow)
     {
@@ -489,11 +706,11 @@ BYTE *RosUmdResource::Form4kTileBlock(BYTE *pInputBuffer, BYTE *pOutBuffer, UINT
         //                  
 
         // Get A block
-        currentTileOffset = pInputBuffer + rowStride * VC4_1KB_SUB_TILE_HEIGHT + VC4_1KB_SUB_TILE_WIDTH_BYTES;
+        currentTileOffset = pInputBuffer + rowStride * subTileHeightPixels + subTileWidthBytes;
         pOutBuffer = Form1kSubTileBlock(currentTileOffset, pOutBuffer, rowStride);
 
         // Get B block
-        currentTileOffset = pInputBuffer + VC4_1KB_SUB_TILE_WIDTH_BYTES;
+        currentTileOffset = pInputBuffer + subTileWidthBytes;
 
         pOutBuffer = Form1kSubTileBlock(currentTileOffset, pOutBuffer, rowStride);
 
@@ -501,7 +718,7 @@ BYTE *RosUmdResource::Form4kTileBlock(BYTE *pInputBuffer, BYTE *pOutBuffer, UINT
         pOutBuffer = Form1kSubTileBlock(pInputBuffer, pOutBuffer, rowStride);
 
         // Get D block
-        currentTileOffset = pInputBuffer + rowStride * VC4_1KB_SUB_TILE_HEIGHT;
+        currentTileOffset = pInputBuffer + rowStride * subTileHeightPixels;
         pOutBuffer = Form1kSubTileBlock(currentTileOffset, pOutBuffer, rowStride);
 
         // return current position in out buffer
@@ -521,15 +738,15 @@ BYTE *RosUmdResource::Form4kTileBlock(BYTE *pInputBuffer, BYTE *pOutBuffer, UINT
         pOutBuffer = Form1kSubTileBlock(pInputBuffer, pOutBuffer, rowStride);
 
         /// Get B block
-        currentTileOffset = pInputBuffer + rowStride * VC4_1KB_SUB_TILE_HEIGHT;
+        currentTileOffset = pInputBuffer + rowStride * subTileHeightPixels;
         pOutBuffer = Form1kSubTileBlock(currentTileOffset, pOutBuffer, rowStride);
 
         // Get C Block
-        currentTileOffset = pInputBuffer + rowStride * VC4_1KB_SUB_TILE_HEIGHT + VC4_1KB_SUB_TILE_WIDTH_BYTES;
+        currentTileOffset = pInputBuffer + rowStride * subTileHeightPixels + subTileWidthBytes;
         pOutBuffer = Form1kSubTileBlock(currentTileOffset, pOutBuffer, rowStride);
 
         // Get D block
-        currentTileOffset = pInputBuffer + VC4_1KB_SUB_TILE_WIDTH_BYTES;
+        currentTileOffset = pInputBuffer + subTileWidthBytes;
         pOutBuffer = Form1kSubTileBlock(currentTileOffset, pOutBuffer, rowStride);
 
         // return current position in out buffer
@@ -540,8 +757,6 @@ BYTE *RosUmdResource::Form4kTileBlock(BYTE *pInputBuffer, BYTE *pOutBuffer, UINT
 // Form (CountX * CountY) tile blocks from InputBuffer and store them in OutBuffer
 void RosUmdResource::ConvertBitmapTo4kTileBlocks(BYTE *InputBuffer, BYTE *OutBuffer, UINT rowStride)
 {
-    // [todo] Currently only 32bpp mode is supported
-
     UINT CountX = m_hwWidthTiles;
     UINT CountY = m_hwHeightTiles;
 
@@ -553,7 +768,7 @@ void RosUmdResource::ConvertBitmapTo4kTileBlocks(BYTE *InputBuffer, BYTE *OutBuf
             // Build 4k blocks from right to left for odd rows
             for (int i = CountX - 1; i >= 0; i--)
             {
-                BYTE *blockStartOffset = InputBuffer + k * rowStride * VC4_4KB_TILE_HEIGHT + i * VC4_4KB_TILE_WIDTH_BYTES;
+                BYTE *blockStartOffset = InputBuffer + k * rowStride * m_TileInfo.VC4_4kBTileHeightPixels + i * m_TileInfo.VC4_4kBTileWidthBytes;
                 OutBuffer = Form4kTileBlock(blockStartOffset, OutBuffer, rowStride, oddRow);
             }
         }
@@ -562,7 +777,7 @@ void RosUmdResource::ConvertBitmapTo4kTileBlocks(BYTE *InputBuffer, BYTE *OutBuf
             // Build 4k blocks from left to right for even rows
             for (UINT i = 0; i < CountX; i++)
             {
-                BYTE *blockStartOffset = InputBuffer + k * rowStride * VC4_4KB_TILE_HEIGHT + i * VC4_4KB_TILE_WIDTH_BYTES;
+                BYTE *blockStartOffset = InputBuffer + k * rowStride * m_TileInfo.VC4_4kBTileHeightPixels + i * m_TileInfo.VC4_4kBTileWidthBytes;
                 OutBuffer = Form4kTileBlock(blockStartOffset, OutBuffer, rowStride, oddRow);
             }
         }

--- a/render-only-sample/rosumd/RosUmdResource.h
+++ b/render-only-sample/rosumd/RosUmdResource.h
@@ -3,6 +3,7 @@
 #include "RosAllocation.h"
 #include "Pixel.hpp"
 #include "RosUmdDebug.h"
+#include "Vc4Hw.h"
 
 class RosUmdResource : public RosAllocationExchange
 {    
@@ -101,13 +102,27 @@ public:
         return m_isPrimary;
     }
 
-    // Tiled textures support
-    void ConvertBitmapTo4kTileBlocks(
-        BYTE *InputBuffer, 
-        BYTE *OutBuffer, 
+    // Support for various texture formats
+    void ConvertInitialTextureFormatToInternal(
+        BYTE *pSrc,
+        BYTE *pDst,
         UINT rowStride);
 
 private:
+
+    void  ConvertBufferto32Bpp(
+        BYTE *pSrc,
+        BYTE *pDst,
+        UINT srcBpp,
+        UINT swizzleMask,
+        UINT pSrcStride,
+        UINT pDstStride);
+
+    // Tiled textures support
+    void ConvertBitmapTo4kTileBlocks(
+        BYTE *InputBuffer,
+        BYTE *OutBuffer,
+        UINT rowStride);
 
     // Tiled textures support
     BYTE *Form1kSubTileBlock(
@@ -120,6 +135,12 @@ private:
         BYTE *pOutBuffer, 
         UINT rowStride, 
         BOOLEAN OddRow);
+
+    void CalculateTilesInfo();
+
+    void FillTileInfo(UINT bpp);
+
+    VC4TileInfo m_TileInfo;
 
 };
 


### PR DESCRIPTION
All, 
This pull request is related to issue #25 - Texture formats needed for Direct2D/XAML.
The basic support for the (new) texture modes is provided: 
DXGI_FORMAT_R8G8_UNORM,
DXGI_FORMAT_R8_UNORM
DXGI_FORMAT_A8_UNORM

Those modes are emulated with RGBA mode.
Textures can be used in both linear and tiled mode.
Driver is able to sample from those types of textures. Textures can't be used as render targets yet. 

Now tiled mode can be also used with 8/16 bpp.

I hope those changes make sense. Thoughts/suggestions are welcome!

Thanks!

Marek
PS Worth to mention, that DXGI_FORMAT_A8_UNORM is mapped to HW format VC4_TEX_RGBX8888 but I think VC4_TEX_RGBA8888 should be used instead. I wasn't sure so I left it as it is.
